### PR TITLE
Support for post-render scripts

### DIFF
--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -54,6 +54,7 @@ pub fn init(args: &ArgMatches) -> Result<(), DynError> {
     let mustache = templating::Mustache::new();
 
     blueprint.render(&mustache, &values, &output_dir)?;
+    blueprint.run_script("post-render.sh", &output_dir, &values)?;
 
     Ok(())
 }

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -54,7 +54,6 @@ pub fn init(args: &ArgMatches) -> Result<(), DynError> {
     let mustache = templating::Mustache::new();
 
     blueprint.render(&mustache, &values, &output_dir)?;
-    blueprint.run_script("post-render.sh", &output_dir, &values)?;
 
     Ok(())
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -23,8 +23,8 @@ fn run_app() -> Result<(), DynError> {
     let yaml = load_yaml!("cli.yml");
     let matches = App::from_yaml(yaml).get_matches();
 
-    if let Some(matches) = matches.subcommand_matches("init") {
-        init::init(matches)?;
+    if let Some(args) = matches.subcommand_matches("init") {
+        init::init(args)?;
     }
 
     Ok(())

--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -129,7 +129,7 @@ impl Blueprint {
             output_dir: &Path,
     ) -> Result<(), DynError> {
         // Iterate through the blueprint templates and render them into our output
-        // directory.  
+        // directory.
 
         println!("render_rec: {:?} {:?}", src_dir, output_dir);
         for entry in fs::read_dir(src_dir)? {
@@ -197,8 +197,6 @@ impl Script {
             .expect("failed to execute script");
 
         println!("Status: {}", output.status);
-        io::stdout().write_all(&output.stdout)?;
-        io::stderr().write_all(&output.stderr)?;
 
         if !output.status.success() {
             let e = ScriptError::new(output.status.code(), String::from_utf8(output.stderr)?);
@@ -258,7 +256,7 @@ impl Display for Blueprint {
         writeln!(f, "{} v{}", &self.metadata.name, &self.metadata.version)?;
         writeln!(f, "{}", &self.metadata.author)?;
         writeln!(f, "{}", &self.metadata.description)?;
-        
+
         Ok(())
     }
 }
@@ -297,7 +295,7 @@ mod tests {
     use crate::blueprint::Blueprint;
     use crate::templating::Mustache;
     use super::*;
-    
+
     #[test]
     fn parse_example_blueprint_metadata() {
         let blueprint = Blueprint::new("test_assets/example_blueprint").unwrap();
@@ -316,7 +314,7 @@ mod tests {
 
         let values: HashMap<_, _> = vec![("name", "my-project"), ("version", "1"), ("foobar", "stuff")]
             .iter().cloned().collect();
-        
+
         let mustache = Mustache::new();
 
         blueprint.render(&mustache, &values, output_dir.path()).unwrap();
@@ -338,7 +336,7 @@ mod tests {
 
         let values: HashMap<_, _> = vec![("name", "my-project"), ("version", "1"), ("foobar", "stuff")]
             .iter().cloned().collect();
-        
+
         let mustache = Mustache::new();
 
         blueprint.render(&mustache, &values, output_dir.path()).unwrap();

--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -160,9 +160,36 @@ impl Blueprint {
         io::stdout().write_all(&output.stdout)?;
         io::stderr().write_all(&output.stderr)?;
 
-        // TODO: return an error including the stderr message and exit code
-        // if !output.status.success() {
-        // }
+        if !output.status.success() {
+            let e = ScriptError::new(output.status.code());
+            return Err(e.into());
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ScriptError {
+    status: Option<i32>,
+}
+
+impl ScriptError {
+    fn new(status: Option<i32>) -> Self {
+        ScriptError {
+            status,
+        }
+    }
+}
+
+impl Error for ScriptError {}
+
+impl Display for ScriptError {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self.status {
+            Some(status) => write!(f, "Script failed with status {}", status)?,
+            None         => write!(f, "Script failed, but didn't exit!")?,
+        }
 
         Ok(())
     }
@@ -277,5 +304,10 @@ mod tests {
 
         assert!(test.find("name: my-project").is_some());
         assert!(test.find("version: 1").is_some());
+    }
+
+    #[test]
+    fn post_script_works() {
+
     }
 }

--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -66,24 +66,24 @@ impl Blueprint {
     }
 
     fn find_scripts(&mut self) -> Result<(), DynError> {
-        self.find_script("post-render")
+        self.post_script = self.find_script("post-render")?;
+
+        Ok(())
     }
 
-    fn find_script(&mut self, script: &str) -> Result<(), DynError> {
+    fn find_script(&mut self, script: &str) -> Result<Option<Script>, DynError> {
         let mut script_path = PathBuf::new();
-        script_path.push(self.dir.path().canonicalize().unwrap());
+        script_path.push(self.dir.path().canonicalize()?);
         script_path.push("scripts");
         script_path.push(format!("{}.sh", script));
 
         if !script_path.exists() {
             #[cfg(debug)]
             eprintln!("No {} script found in blueprint scripts directory - skipping", script);
-            return Ok(());
+            return Ok(None);
         }
 
-        self.post_script = Some(Script::new(script.to_string(), script_path));
-
-        Ok(())
+        Ok(Some(Script::new(script.to_string(), script_path)))
     }
 
     pub fn values(&self) -> impl Iterator<Item=&ValueSpec> {

--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::error::Error;
 use std::fs;
-use std::io::{self, Write};
 
 use tempdir::TempDir;
 use git2::Repository;

--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -160,6 +160,10 @@ impl Blueprint {
         io::stdout().write_all(&output.stdout)?;
         io::stderr().write_all(&output.stderr)?;
 
+        // TODO: return an error including the stderr message and exit code
+        // if !output.status.success() {
+        // }
+
         Ok(())
     }
 }

--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -83,7 +83,7 @@ impl Blueprint {
             return Ok(None);
         }
 
-        Ok(Some(Script::new(script.to_string(), script_path)))
+        Ok(Some(Script::new(script, script_path)))
     }
 
     pub fn values(&self) -> impl Iterator<Item=&ValueSpec> {
@@ -172,10 +172,10 @@ struct Script {
 }
 
 impl Script {
-    fn new(name: String, path: PathBuf) -> Self {
+    fn new(name: &str, path: PathBuf) -> Self {
         Script {
-            name,
-            path,
+            name: name.to_string(),
+            path: path,
         }
     }
 
@@ -294,6 +294,7 @@ mod tests {
     use tempdir::TempDir;
     use crate::blueprint::Blueprint;
     use crate::templating::Mustache;
+    use super::*;
     
     #[test]
     fn parse_example_blueprint_metadata() {
@@ -347,7 +348,20 @@ mod tests {
     }
 
     #[test]
-    fn post_script_works() {
+    fn script_can_be_run_successfully() {
+        let script = Script::new("some script", PathBuf::from("test_assets/scripts/hello_world.sh"));
 
+        let values = HashMap::new();
+        script.run(Path::new("."), &values).unwrap();
+    }
+
+    #[test]
+    fn run_script_returns_error_on_failing_script() {
+        let script = Script::new("some script", PathBuf::from("test_assets/scripts/failing.sh"));
+
+        let values = HashMap::new();
+        if let Ok(()) = script.run(Path::new("."), &values) {
+            panic!("The failing script didn't cause an error!");
+        }
     }
 }

--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -311,12 +311,9 @@ mod tests {
 
         let output_dir = TempDir::new("my-project").unwrap();
 
-        let values: HashMap<_, _> = vec![("name", "my-project"), ("version", "1"), ("foobar", "stuff")]
-            .iter().cloned().collect();
-
         let mustache = Mustache::new();
 
-        blueprint.render(&mustache, &values, output_dir.path()).unwrap();
+        blueprint.render(&mustache, &test_values(), output_dir.path()).unwrap();
 
         let test = fs::read_to_string(output_dir.path().join("test.yaml")).unwrap();
         let another_test = fs::read_to_string(output_dir.path().join("another-test.yaml")).unwrap();
@@ -333,12 +330,9 @@ mod tests {
 
         let output_dir = TempDir::new("my-project").unwrap();
 
-        let values: HashMap<_, _> = vec![("name", "my-project"), ("version", "1"), ("foobar", "stuff")]
-            .iter().cloned().collect();
-
         let mustache = Mustache::new();
 
-        blueprint.render(&mustache, &values, output_dir.path()).unwrap();
+        blueprint.render(&mustache, &test_values(), output_dir.path()).unwrap();
 
         let test = fs::read_to_string(output_dir.path().join("dir/test.yaml")).unwrap();
 
@@ -355,12 +349,33 @@ mod tests {
     }
 
     #[test]
-    fn run_script_returns_error_on_failing_script() {
+    fn running_failing_script_returns_an_error() {
         let script = Script::new("some script", PathBuf::from("test_assets/scripts/failing.sh"));
 
         let values = HashMap::new();
         if let Ok(()) = script.run(Path::new("."), &values) {
             panic!("The failing script didn't cause an error!");
         }
+    }
+
+    #[test]
+    fn blueprint_post_script_is_found_and_run() {
+        let blueprint = Blueprint::new("test_assets/example_blueprint_with_scripts").unwrap();
+
+        let output_dir = TempDir::new("my-project").unwrap();
+
+        let mustache = Mustache::new();
+
+        blueprint.render(&mustache, &test_values(), output_dir.path()).unwrap();
+
+        let script_output = fs::read_to_string(output_dir.path().join("script_output.md")).unwrap();
+
+        assert_eq!(script_output.as_str(), "something123");
+    }
+
+    // Test helpers
+    fn test_values() -> HashMap<&'static str, &'static str> {
+        vec![("name", "my-project"), ("version", "1"), ("foobar", "stuff")]
+            .iter().cloned().collect()
     }
 }

--- a/src/blueprint.rs
+++ b/src/blueprint.rs
@@ -3,7 +3,7 @@ use std::fmt::Formatter;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::error::Error;
 use std::fs;
 use std::io::{self, Write};
@@ -191,6 +191,8 @@ impl Script {
             .arg(&self.path)
             .envs(values)
             .current_dir(working_dir)
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
             .output()
             .expect("failed to execute script");
 

--- a/test_assets/example_blueprint_with_scripts/blueprint/another-test.yaml
+++ b/test_assets/example_blueprint_with_scripts/blueprint/another-test.yaml
@@ -1,0 +1,4 @@
+project:
+  name: hardcoded-name
+  version: {{ version }}
+  stuff: {{ foobar }}

--- a/test_assets/example_blueprint_with_scripts/blueprint/dir/test.yaml
+++ b/test_assets/example_blueprint_with_scripts/blueprint/dir/test.yaml
@@ -1,0 +1,4 @@
+project:
+  name: {{ name }}
+  version: {{ version }}
+  stuff: foobar

--- a/test_assets/example_blueprint_with_scripts/blueprint/test.yaml
+++ b/test_assets/example_blueprint_with_scripts/blueprint/test.yaml
@@ -1,0 +1,5 @@
+project:
+  name: {{ name }}
+  version: {{ version }}
+  stuff: foobar
+  extra: {{ extra_info }}

--- a/test_assets/example_blueprint_with_scripts/metadata.yaml
+++ b/test_assets/example_blueprint_with_scripts/metadata.yaml
@@ -1,0 +1,13 @@
+name: example-blueprint
+version: 1
+author: Brian S. <brian.stewart@jamf.com>, Tomasz K. <tomasz.kurcz@jamf.com>
+description: Just an example blueprint for `express`.
+values:
+- name: name
+  description: The name of your project
+  required: true
+- name: version
+  description: The version of your project
+  default: 1
+- name: extra_info
+  description: This isn't really needed

--- a/test_assets/example_blueprint_with_scripts/scripts/post-render.sh
+++ b/test_assets/example_blueprint_with_scripts/scripts/post-render.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo -n "something123" > script_output.md

--- a/test_assets/scripts/failing.sh
+++ b/test_assets/scripts/failing.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 1

--- a/test_assets/scripts/hello_world.sh
+++ b/test_assets/scripts/hello_world.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "Hello world!"


### PR DESCRIPTION
@uint-jamf Can you take a look at the TODO at blueprint.rs:163 and let me know how you would implement that?

This PR is functional except for returning an error when the script fails.

Each key/value in `values` is provided to the script as an environment variable, which makes implementing the scripts easy.
Scripts need to be in a `scripts` directory, and so far only `post-render.sh` will be run, and only if it exists.

One more thought: we should implement logging levels sooner than later.